### PR TITLE
Enable API key for yarn test in master branch workflow

### DIFF
--- a/.github/workflows/development-branch.yml
+++ b/.github/workflows/development-branch.yml
@@ -22,6 +22,8 @@ jobs:
         run: yarn install
       - name: yarn build
         run: yarn build
+        env:
+          REACT_APP_FIREBASE_API_KEY: ${{ secrets.REACT_APP_FIREBASE_API_KEY }}
       - name: yarn test
         run: yarn test
         env:

--- a/.github/workflows/development-branch.yml
+++ b/.github/workflows/development-branch.yml
@@ -22,8 +22,6 @@ jobs:
         run: yarn install
       - name: yarn build
         run: yarn build
-        env:
-          REACT_APP_FIREBASE_API_KEY: ${{ secrets.REACT_APP_FIREBASE_API_KEY }}
       - name: yarn test
         run: yarn test
         env:

--- a/.github/workflows/master-branch.yml
+++ b/.github/workflows/master-branch.yml
@@ -25,6 +25,8 @@ jobs:
           REACT_APP_FIREBASE_API_KEY: ${{ secrets.REACT_APP_FIREBASE_API_KEY }}
       - name: yarn test
         run: yarn test
+        env:
+          REACT_APP_FIREBASE_API_KEY: ${{ secrets.REACT_APP_FIREBASE_API_KEY }}
       - name: Archive Production Artifact
         uses: actions/upload-artifact@master
         with:


### PR DESCRIPTION
Forgot to enable API key for both workflows